### PR TITLE
Support for mmdf

### DIFF
--- a/beater/gpfs.go
+++ b/beater/gpfs.go
@@ -87,7 +87,7 @@ func (bt *Gpfsbeat) MmDf() ([]parser.ParseResult, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), mmdfTimeout)
 		defer cancel()
 
-		cmd := exec.CommandContext(ctx, bt.config.MMDfCommand, "-Y", device)
+		cmd := exec.CommandContext(ctx, bt.config.MMDfCommand, device, "-Y")
 		var out bytes.Buffer
 		cmd.Stdout = &out
 

--- a/beater/gpfs.go
+++ b/beater/gpfs.go
@@ -74,3 +74,6 @@ func (bt *Gpfsbeat) MmRepQuota() ([]parser.QuotaInfo, error) {
 	}
 	return quotas, nil
 }
+
+// MmDf is a wrapper around the mmdf command
+func (bt *Gpfsbeat) MmDf() (parser.MmDfInfo, error) {}

--- a/beater/gpfs.go
+++ b/beater/gpfs.go
@@ -99,7 +99,7 @@ func (bt *Gpfsbeat) MmDf() ([]parser.ParseResult, error) {
 		}
 
 		var qs []parser.ParseResult
-		qs, err = parser.ParseMmDf(out.String())
+		qs, err = parser.ParseMmDf(device, out.String())
 		if err != nil {
 			var nope []parser.ParseResult
 			return nope, errors.New("mmdf info could not be parsed")

--- a/beater/gpfsbeat.go
+++ b/beater/gpfsbeat.go
@@ -65,7 +65,7 @@ func (bt *Gpfsbeat) Run(b *beat.Beat) error {
 		}
 
 		gpfsQuota, err := bt.MmRepQuota()
-		logp.Warn("retrieved quota information from mmrepquota")
+		logp.Info("retrieved quota information from mmrepquota")
 		if err != nil {
 			panic("Could not get quota information")
 		}
@@ -80,7 +80,26 @@ func (bt *Gpfsbeat) Run(b *beat.Beat) error {
 			}
 			bt.client.PublishEvent(event)
 		}
-		logp.Info("Events sent")
+		logp.Info("mmrepquota events sent")
+
+		mmdfinfos, err := bt.MmDf()
+		logp.Info("Retrieved usage information from mmdf")
+		if err != nil {
+			panic("Could not get mmdf information")
+		}
+
+		for _, i := range mmdfinfos {
+			info := i.ToMapStr()
+			event := common.MapStr{
+				"@timestamp": common.Time(time.Now()),
+				"type":       b.Name,
+				"counter":    counter,
+				"mmdf":       info,
+			}
+			bt.client.PublishEvent(event)
+		}
+		logp.Info("mmdf events sent")
+
 		counter++
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ type Config struct {
 	Devices           []string      `config:"devices"`
 	MMRepQuotaCommand string        `config:"mmrepquota"`
 	MMLsFsCommand     string        `config:"mmlsfs"`
-	MMDfCommand       string        `config:"mmsf"`
+	MMDfCommand       string        `config:"mmdf"`
 }
 
 // DefaultConfig should be overridden

--- a/parser/mmdf.go
+++ b/parser/mmdf.go
@@ -6,6 +6,7 @@ import (
 
 // MmDfNSDInfo represents the `nsd` output line information
 type MmDfNSDInfo struct {
+	device                  string
 	version                 int64
 	nsdname                 string
 	storagePool             string
@@ -23,6 +24,7 @@ type MmDfNSDInfo struct {
 // ToMapStr turns the nsd information into a common.MapStr
 func (m *MmDfNSDInfo) ToMapStr() common.MapStr {
 	return common.MapStr{
+		"device":                    m.device,
 		"version":                   m.version,
 		"nsd_name":                  m.nsdname,
 		"storage_pool":              m.storagePool,
@@ -38,8 +40,14 @@ func (m *MmDfNSDInfo) ToMapStr() common.MapStr {
 	}
 }
 
+// UpdateDevice sets the device name
+func (m *MmDfNSDInfo) UpdateDevice(device string) {
+	m.device = device
+}
+
 // MmDfPoolTotalInfo represent the `poolTotal` output line information
 type MmDfPoolTotalInfo struct {
+	device                  string
 	version                 int64
 	poolName                string
 	poolSize                int64
@@ -53,6 +61,7 @@ type MmDfPoolTotalInfo struct {
 // ToMapStr turns the pool total information into a common.MapStr
 func (m *MmDfPoolTotalInfo) ToMapStr() common.MapStr {
 	return common.MapStr{
+		"device":                    m.device,
 		"version":                   m.version,
 		"pool_name":                 m.poolName,
 		"pool_size":                 m.poolSize,
@@ -65,8 +74,14 @@ func (m *MmDfPoolTotalInfo) ToMapStr() common.MapStr {
 	}
 }
 
+// UpdateDevice sets the device name
+func (m *MmDfPoolTotalInfo) UpdateDevice(device string) {
+	m.device = device
+}
+
 // MmDfFsTotalInfo represents the `fstotal` output line information
 type MmDfFsTotalInfo struct {
+	device                  string
 	version                 int64
 	fsSize                  int64
 	freeBlocks              int64
@@ -78,6 +93,7 @@ type MmDfFsTotalInfo struct {
 // ToMapStr turns the fs total information into a common.MapStr
 func (m *MmDfFsTotalInfo) ToMapStr() common.MapStr {
 	return common.MapStr{
+		"device":                    m.device,
 		"version":                   m.version,
 		"fs_size":                   m.fsSize,
 		"free_blocks":               m.freeBlocks,
@@ -89,8 +105,14 @@ func (m *MmDfFsTotalInfo) ToMapStr() common.MapStr {
 
 }
 
+// UpdateDevice sets the device name
+func (m *MmDfFsTotalInfo) UpdateDevice(device string) {
+	m.device = device
+}
+
 // MmDfInodeInfo represents the `inode` ouput line information
 type MmDfInodeInfo struct {
+	device          string
 	version         int64
 	usedInodes      int64
 	freeInodes      int64
@@ -101,6 +123,7 @@ type MmDfInodeInfo struct {
 // ToMapStr turns the inode information into a common.MapStr
 func (m *MmDfInodeInfo) ToMapStr() common.MapStr {
 	return common.MapStr{
+		"device":           m.device,
 		"version":          m.version,
 		"used_inodes":      m.usedInodes,
 		"free_inodes":      m.freeInodes,
@@ -108,6 +131,11 @@ func (m *MmDfInodeInfo) ToMapStr() common.MapStr {
 		"max_inodex":       m.maxInodes,
 		"info_type":        "inodes",
 	}
+}
+
+// UpdateDevice sets the device name
+func (m *MmDfInodeInfo) UpdateDevice(device string) {
+	m.device = device
 }
 
 func parseMmDfCallback(fields []string, fieldMap map[string]int) ParseResult {
@@ -163,7 +191,7 @@ func parseMmDfCallback(fields []string, fieldMap map[string]int) ParseResult {
 }
 
 // ParseMmDf converts the lines in the output string into the desired information
-func ParseMmDf(output string) ([]ParseResult, error) {
+func ParseMmDf(device string, output string) ([]ParseResult, error) {
 
 	var prefixFieldlocation = 0
 	var identifierFieldLocation = 1
@@ -176,6 +204,7 @@ func ParseMmDf(output string) ([]ParseResult, error) {
 		if info == nil {
 			continue // line could not be parsed
 		}
+		info.UpdateDevice(device)
 		dfs = append(dfs, info)
 	}
 

--- a/parser/mmdf.go
+++ b/parser/mmdf.go
@@ -1,0 +1,23 @@
+package parser
+
+import "github.com/elastic/beats/libbeat/common"
+
+// DfInfo contains the relevant information obtained in a single run of mmdf
+type DfInfo struct {
+}
+
+// GetDfEvent turns the mmdf information into a MapStr
+func GetDfEvent(dfinfo *DfInfo) common.MapStr {
+	return common.MapStr{}
+
+}
+
+func parseMmDfInfoCallback(fields []string, fieldMap map[string]int) interface{} {
+
+	return nil
+}
+
+// ParseMmDf converts the lines in the output string into the desired information
+func ParseMmDf(output string) (DfInfo, error) {
+	return nil, nil
+}

--- a/parser/mmdf.go
+++ b/parser/mmdf.go
@@ -3,7 +3,54 @@ package parser
 import "github.com/elastic/beats/libbeat/common"
 
 // DfInfo contains the relevant information obtained in a single run of mmdf
-type DfInfo struct {
+type DfInfo interface {
+}
+
+// MmDfNSDInfo represents the `nsd` output line information
+type MmDfNSDInfo struct {
+	version                 int64
+	nsdname                 string
+	storagePool             string
+	diskSize                int64
+	failureGroup            int64
+	metadata                bool
+	data                    bool
+	freeBlocks              int64
+	freeBlocksPercentage    int64
+	freeFragments           int64
+	freeFragmentsPercentage int64
+	diskAvailableForAlloc   string // no idea what this should be
+}
+
+// MmDfPoolTotalInfo represent the `poolTotal` output line information
+type MmDfPoolTotalInfo struct {
+	version                 int64
+	poolName                string
+	poolSize                int64
+	freeBlocks              int64
+	freeBlocksPercentage    int64
+	freeFragments           int64
+	freeFragmentsPercentage int64
+	maxDiskSize             int64
+}
+
+// MmDfFsTotalInfo represents the `fstotal` output line information
+type MmDfFsTotalInfo struct {
+	version                 int64
+	fsSize                  int64
+	freeBlocks              int64
+	freeBlocksPercentage    int64
+	freeFragments           int64
+	freeFragmentsPercentage int64
+}
+
+// MmDfInodeInfo represents the `inode` ouput line information
+type MmDfInodeInfo struct {
+	version         int64
+	usedInodes      int64
+	freeInodes      int64
+	allocatedInodes int64
+	maxInodes       int64
 }
 
 // GetDfEvent turns the mmdf information into a MapStr
@@ -19,5 +66,17 @@ func parseMmDfInfoCallback(fields []string, fieldMap map[string]int) interface{}
 
 // ParseMmDf converts the lines in the output string into the desired information
 func ParseMmDf(output string) (DfInfo, error) {
-	return nil, nil
+
+	var prefixFieldlocation = 0
+	var identifierFieldLocation = 1
+	var headerFieldLocation = 2
+
+	mmdfs, _ := parseGpfsYOutput(prefixFieldlocation, identifierFieldLocation, headerFieldLocation, "mmrepquota", output, parseMmRepQuotaCallback)
+
+	var quotaInfos = make([]QuotaInfo, 0, len(qs))
+	for _, q := range qs {
+		quotaInfos = append(quotaInfos, q.(QuotaInfo))
+	}
+
+	return quotaInfos, nil	return nil, nil
 }

--- a/parser/mmlsfs.go
+++ b/parser/mmlsfs.go
@@ -14,6 +14,9 @@ func (m *MmLsFsInfo) ToMapStr() common.MapStr {
 	}
 }
 
+// UpdateDevice does not do anything, since we already have that information
+func (m *MmLsFsInfo) UpdateDevice(device string) {}
+
 // ParseMmLsFs returns the different devices in the GPFS cluster
 func ParseMmLsFs(output string) ([]string, error) {
 	var prefixFieldlocation = 0

--- a/parser/mmrepquota.go
+++ b/parser/mmrepquota.go
@@ -42,6 +42,9 @@ func (q *QuotaInfo) ToMapStr() common.MapStr {
 	}
 }
 
+// UpdateDevice does not do anything, since we already have that information
+func (q *QuotaInfo) UpdateDevice(device string) {}
+
 func parseMmRepQuotaCallback(fields []string, fieldMap map[string]int) ParseResult {
 	qi := QuotaInfo{
 		filesystem: fields[fieldMap["filesystemName"]],

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -60,12 +60,12 @@ func parseGpfsYOutput(
 	headerFieldLocation int,
 	prefix string,
 	output string,
-	fn parseCallBack) ([]interface{}, error) {
+	fn parseCallBack) ([]ParseResult, error) {
 
 	lines := strings.Split(output, "\n")
 	var headerMap = make(map[string](map[string]int))
 
-	result := make([]interface{}, 0, len(lines))
+	result := make([]ParseResult, 0, len(lines))
 
 	for _, line := range lines {
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -11,6 +11,7 @@ import (
 // ParseResult represents the result of parsing one or more output lines from a GPFS command
 type ParseResult interface {
 	ToMapStr() common.MapStr
+	UpdateDevice(string) // in case we need the device information, we should be able to set it if it is not provided
 }
 type parseCallBack func([]string, map[string]int) ParseResult
 


### PR DESCRIPTION
- parses four kinds of mmdf output lines
    - nsd
    - pooltotal
    - fstotal
    - inodes
- adds an info_type in the resulting JSON to identify the line type
- each output line type may occur multiple times: for each occurrence, a document is stored in ES